### PR TITLE
Avoid the blank of adding link.

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -244,7 +244,7 @@ export const toggleSelectionLink = (editorState, href, target) => {
     }))
 
     nextEditorState = EditorState.push(nextEditorState, Modifier.insertText(
-      nextEditorState.getCurrentContent(), nextEditorState.getSelection(), ' '
+      nextEditorState.getCurrentContent(), nextEditorState.getSelection(), ''
     ), 'insert-text')
 
     return nextEditorState


### PR DESCRIPTION
When I use `braft-editor` to add link, it will auto add blank in the end. Here not need the ' '.

In addition, maybe you should add source link of this repo in `npmjs.com`. It may be hard to find source code.