### PR TITLE
Fix decreaseSelectionIndent with a custom maxIndent value

### DIFF
--- a/dist/content.js
+++ b/dist/content.js
@@ -308,9 +308,9 @@ var increaseSelectionIndent = exports.increaseSelectionIndent = function increas
   return toggleSelectionIndent(editorState, currentIndent + 1, maxIndent);
 };
 
-var decreaseSelectionIndent = exports.decreaseSelectionIndent = function decreaseSelectionIndent(editorState) {
+var decreaseSelectionIndent = exports.decreaseSelectionIndent = function decreaseSelectionIndent(editorState, maxIndent) {
   var currentIndent = getSelectionBlockData(editorState, 'textIndent') || 0;
-  return toggleSelectionIndent(editorState, currentIndent - 1);
+  return toggleSelectionIndent(editorState, currentIndent - 1, maxIndent);
 };
 
 var toggleSelectionColor = exports.toggleSelectionColor = function toggleSelectionColor(editorState, color) {

--- a/src/content.js
+++ b/src/content.js
@@ -299,9 +299,9 @@ export const increaseSelectionIndent = (editorState, maxIndent = 6) => {
   return toggleSelectionIndent(editorState, currentIndent + 1, maxIndent)
 }
 
-export const decreaseSelectionIndent = (editorState) => {
+export const decreaseSelectionIndent = (editorState, maxIndent) => {
   const currentIndent = getSelectionBlockData(editorState, 'textIndent') || 0
-  return toggleSelectionIndent(editorState, currentIndent - 1)
+  return toggleSelectionIndent(editorState, currentIndent - 1, maxIndent)
 }
 
 export const toggleSelectionColor = (editorState, color) => {


### PR DESCRIPTION
`increaseSelectionIndent` allowed a custom `maxIndent` to be passed in, but `decreaseSelectionIndent` did not. This made it possible that in `toggleSelectionIndent` it would not decrease the indent if it was greater than 6 since it was only checking the default `maxIndent` value.

Adding support for larger `maxIndent` values was achieved by passing in a value to override the default.