### PR TITLE
Update immutable to v3.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Margox",
   "license": "MIT",
   "peerDependencies": {
-    "immutable": "~3.7.4",
+    "immutable": "~3.8.2",
     "braft-convert": "^2.1.4",
     "draft-js": "^0.10.5",
     "draftjs-utils": "^0.9.4"


### PR DESCRIPTION
to avoid a huge amount of errors which kill performance of the whole rich text editor:
```
RichTextEditorInternal-c3e0c789.js:1 iterable.length has been deprecated, use iterable.size or iterable.count(). This warning will become a silent error in a future version. Error
    at qe.get (http://localhost:3000/static/js/vendors-node_modules_meemoo_react-components_dist_esm_RichTextEditorInternal-c3e0c789_js.chunk.js:2559:21)
    at isArrayLike (http://localhost:3000/static/js/bundle.js:201412:90)
    at keys (http://localhost:3000/static/js/bundle.js:202468:69)
    at baseGetAllKeys (http://localhost:3000/static/js/bundle.js:194024:16)
    at getAllKeys (http://localhost:3000/static/js/bundle.js:197502:72)
    at baseClone (http://localhost:3000/static/js/bundle.js:193616:35)
    at http://localhost:3000/static/js/bundle.js:193624:79
    at arrayEach (http://localhost:3000/static/js/bundle.js:192794:9)
    at baseClone (http://localhost:3000/static/js/bundle.js:193617:61)
    at http://localhost:3000/static/js/bundle.js:193624:79
```